### PR TITLE
Refactor code in order to strip queryparams from path in pact output …

### DIFF
--- a/wiremock-pact-lib/src/main/java/se/bjurr/wiremockpact/wiremockpactlib/api/WireMockPactApi.java
+++ b/wiremock-pact-lib/src/main/java/se/bjurr/wiremockpact/wiremockpactlib/api/WireMockPactApi.java
@@ -15,6 +15,7 @@ import au.com.dius.pact.core.model.SynchronousRequestResponse;
 import au.com.dius.pact.core.model.V4Interaction.SynchronousHttp;
 import au.com.dius.pact.core.model.V4Pact;
 import com.github.tomakehurst.wiremock.common.Metadata;
+import com.github.tomakehurst.wiremock.common.Urls;
 import com.github.tomakehurst.wiremock.http.HttpHeader;
 import com.github.tomakehurst.wiremock.http.HttpHeaders;
 import com.github.tomakehurst.wiremock.http.LoggedResponse;
@@ -88,7 +89,12 @@ public final class WireMockPactApi {
 
       final IRequest pactRequest = asSynchronousRequestResponse.getRequest();
       pactRequest.setMethod(wireMockRequest.getMethod().getName());
-      pactRequest.setPath(wireMockRequest.getUrl());
+      pactRequest.setPath(Urls.getPath(wireMockRequest.getUrl()));
+      pactRequest
+          .getQuery()
+          .putAll(
+              Urls.splitQueryFromUrl(wireMockRequest.getUrl()).entrySet().stream()
+                  .collect(Collectors.toMap(Entry::getKey, e -> e.getValue().values())));
       pactRequest.setBody(new OptionalBody(State.PRESENT, wireMockRequest.getBody()));
       for (final HttpHeader header :
           Optional.ofNullable(wireMockRequest.getHeaders()).orElse(new HttpHeaders()).all()) {

--- a/wiremock-pact-lib/src/test/java/se/bjurr/wiremockpact/wiremockpact/test/GetTest.java
+++ b/wiremock-pact-lib/src/test/java/se/bjurr/wiremockpact/wiremockpact/test/GetTest.java
@@ -264,7 +264,12 @@ public class GetTest extends BaseTest {
           ]
         },
         "method": "GET",
-        "path": "/getrequest_1?a=b"
+        "path": "/getrequest_1",
+        "query": {
+          "a": [
+            "b"
+          ]
+        }
       },
       "response": {
         "body": {
@@ -291,7 +296,13 @@ public class GetTest extends BaseTest {
           ]
         },
         "method": "GET",
-        "path": "/getrequest_2?a=b&a=b"
+        "path": "/getrequest_2",
+        "query": {
+          "a": [
+            "b",
+            "b"
+          ]
+        }
       },
       "response": {
         "body": {
@@ -318,8 +329,19 @@ public class GetTest extends BaseTest {
           ]
         },
         "method": "GET",
-        "path": "/getrequest_3?a=b&c=d&e=f"
-      },
+        "path": "/getrequest_3",
+        "query": {
+          "a": [
+            "b"
+          ],
+          "c": [
+            "d"
+          ],
+          "e": [
+            "f"
+          ]
+        }
+       },
       "response": {
         "body": {
           "content": ""

--- a/wiremock-pact-lib/src/test/java/se/bjurr/wiremockpact/wiremockpact/test/PostTest.java
+++ b/wiremock-pact-lib/src/test/java/se/bjurr/wiremockpact/wiremockpact/test/PostTest.java
@@ -335,7 +335,12 @@ public class PostTest extends BaseTest {
           ]
         },
         "method": "POST",
-        "path": "/postrequest?a=b"
+        "path": "/postrequest",
+        "query": {
+          "a": [
+            "b"
+          ]
+        }
       },
       "response": {
         "body": {
@@ -372,7 +377,13 @@ public class PostTest extends BaseTest {
           ]
         },
         "method": "POST",
-        "path": "/postrequest?a=b&a=b"
+        "path": "/postrequest",
+        "query": {
+          "a": [
+            "b",
+            "b"
+          ]
+        }
       },
       "response": {
         "body": {
@@ -409,7 +420,18 @@ public class PostTest extends BaseTest {
           ]
         },
         "method": "POST",
-        "path": "/postrequest?a=b&c=d&e=f"
+        "path": "/postrequest",
+        "query": {
+          "a": [
+            "b"
+          ],
+          "c": [
+            "d"
+          ],
+          "e": [
+            "f"
+          ]
+        }
       },
       "response": {
         "body": {

--- a/wiremock-pact-lib/src/test/java/se/bjurr/wiremockpact/wiremockpact/test/QueryParamsTest.java
+++ b/wiremock-pact-lib/src/test/java/se/bjurr/wiremockpact/wiremockpact/test/QueryParamsTest.java
@@ -1,0 +1,87 @@
+package se.bjurr.wiremockpact.wiremockpact.test;
+
+import com.github.tomakehurst.wiremock.client.WireMock;
+import io.restassured.RestAssured;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import se.bjurr.wiremockpact.wiremockpact.testutils.BaseTest;
+
+public class QueryParamsTest extends BaseTest {
+
+  @BeforeEach
+  public void beforeEach() {
+    WireMock.reset();
+    WireMock.stubFor(WireMock.any(WireMock.anyUrl()).willReturn(WireMock.ok()));
+  }
+
+  @Test
+  public void testThatSingleHeaderIsRecorded() {
+    RestAssured.given()
+        .queryParam("foo", "bar")
+        .log()
+        .all()
+        .when()
+        .put("/therequest")
+        .then()
+        .statusCode(200);
+
+    this.assertPactEquals(
+        """
+        {
+          "consumer": {
+            "name": "this-is-me"
+          },
+          "interactions": [
+            {
+              "description": "PUT /therequest?foo=bar -> 200",
+              "key": "a08c5440",
+              "pending": false,
+              "request": {
+                "body": {
+                  "content": ""
+                },
+                "headers": {
+                  "Accept": [
+                    "*/*"
+                  ],
+                  "Accept-Encoding": [
+                    "gzip,deflate"
+                  ],
+                  "Content-Length": [
+                    "0"
+                  ]
+                },
+                "method": "PUT",
+                "path": "/therequest",
+                "query": {
+                  "foo": [
+                    "bar"
+                  ]
+                }
+              },
+              "response": {
+                "body": {
+                  "content": ""
+                },
+                "status": 200
+              },
+              "type": "Synchronous/HTTP"
+            }
+          ],
+          "metadata": {
+            "pact-jvm": {
+              "version": "4.6.9"
+            },
+            "pactSpecification": {
+              "version": "4.0"
+            }
+          },
+          "provider": {
+            "name": "this-is-you"
+          }
+        }
+
+
+        """);
+  }
+}


### PR DESCRIPTION
…and get them handled separately

Currently query params are treated as part of path in pact output. It makes difficult or impossible to use tools like @pactflow/swagger-mock-validator because path (with queryParams) are not found in openapi spec.

## References

- TODO

<!-- References to relevant GitHub issues and pull requests, esp. upstream and downstream changes -->

## Submitter checklist

- [ ] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [x] Test coverage that demonstrates that the change works as expected
- [ ] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
